### PR TITLE
Add test dashboard

### DIFF
--- a/admin/src/common/components/dashboard/components/item.component.spec.tsx
+++ b/admin/src/common/components/dashboard/components/item.component.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../test/';
+
+//VM
+import { DashboardItemProps } from '../dashboard.vm';
+
+//Componente
+import { ItemComponent, ClassesProps } from './item.component';
+
+//Material ui
+import PeopleAltIcon from '@material-ui/icons/PeopleAlt';
+
+describe('common/dashboard/components/ItemComponent', () => {
+  it('should be render as expected passing required properties', () => {
+    // Arrange
+    const props = {
+      item: {
+        icon: PeopleAltIcon,
+        title: 'test name',
+        linkTo: '/test-link',
+      } as DashboardItemProps,
+      dataTestId: 'test-item',
+    };
+
+    // Act
+    const { getByRole } = renderWithRouter(
+      <ItemComponent {...props} />,
+      <>
+        <Route path={props.item.linkTo} component={() => <h1>Test route destination</h1>} />
+      </>,
+    );
+
+    const element = getByRole('link');
+
+    // Assert
+    expect(element).toBeInTheDocument();
+  });
+
+  it('should be render as expected passing required and optional properties', () => {
+    // Arrange
+    const props = {
+      item: {
+        icon: PeopleAltIcon,
+        title: 'test name',
+        linkTo: '/test-link',
+        subtitle: 'test subtitle',
+      } as DashboardItemProps,
+      classes: {
+        root: 'test-root-class',
+        icon: 'test-icon-class',
+        title: 'test-name-class',
+        subtitle: 'test-subtitle-class',
+      } as ClassesProps,
+      dataTestId: 'test-item',
+    };
+
+    // Act
+    const { getByRole } = renderWithRouter(
+      <ItemComponent {...props} />,
+      <>
+        <Route path={props.item.linkTo} component={() => <h1>Test route destination</h1>} />
+      </>,
+    );
+
+    const element = getByRole('link');
+    const title = getByRole('heading', { level: 5 });
+    const subTitle = getByRole('heading', { level: 6 });
+
+    // Assert
+    expect(element).toHaveClass(props.classes.root);
+    expect(title).toHaveClass(props.classes.title);
+    expect(subTitle).toHaveClass(props.classes.subtitle);
+  });
+
+  it('should navigate to route when click on item component', () => {
+    // Arrange
+    const props = {
+      item: {
+        icon: PeopleAltIcon,
+        title: 'test name',
+        linkTo: '/test-link',
+        subtitle: 'test subtitle',
+      } as DashboardItemProps,
+      classes: {
+        root: 'test-root-class',
+        icon: 'test-icon-class',
+        title: 'test-name-class',
+        subtitle: 'test-subtitle-class',
+      } as ClassesProps,
+      dataTestId: 'test-item',
+    };
+
+    // Act
+    const { getByRole } = renderWithRouter(
+      <ItemComponent {...props} />,
+      <>
+        <Route path={props.item.linkTo} component={() => <h1>Test route destination</h1>} />
+      </>,
+    );
+
+    const element = getByRole('link');
+
+    userEvent.click(element);
+
+    const title = getByRole('heading', { level: 1 });
+
+    // Assert
+    expect(title).toBeInTheDocument();
+  });
+});

--- a/admin/src/common/components/dashboard/dashboard.component.spec.tsx
+++ b/admin/src/common/components/dashboard/dashboard.component.spec.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import { renderWithRouter } from './../test/';
+
+//VM
+import { DashboardItemProps } from './dashboard.vm';
+
+//Componente
+import { DashboardComponent } from './dashboard.component';
+
+//Material ui
+import PeopleAltIcon from '@material-ui/icons/PeopleAlt';
+
+describe('common/DashboardComponent', () => {
+  it('should be render as expected passing required properties', () => {
+    // Arrange
+    const props = {
+      items: [
+        {
+          title: 'test name',
+          icon: PeopleAltIcon,
+          linkTo: 'linkTo',
+        },
+      ] as DashboardItemProps[],
+    };
+
+    // Act
+    const { getByRole } = renderWithRouter(
+      <DashboardComponent {...props} />,
+      <>
+        <Route path={props.items[0].linkTo} component={() => <h1>Test route destination</h1>} />
+      </>,
+    );
+    const element = getByRole('link');
+
+    // Assert
+    expect(element).toBeInTheDocument();
+  });
+
+  it('should be render as expected passing required and optional properties', () => {
+    // Arrange
+    const props = {
+      items: [
+        {
+          title: 'test name',
+          icon: PeopleAltIcon,
+          linkTo: 'linkTo',
+        },
+      ] as DashboardItemProps[],
+      classes: {
+        root: 'test-root-class',
+        items: 'test-items-class',
+        item: 'test-item-class',
+      },
+      dataTestId: 'dashboard-id',
+    };
+
+    // Act
+    const { getByTestId } = renderWithRouter(
+      <DashboardComponent {...props} />,
+      <>
+        <Route path={props.items[0].linkTo} component={() => <h1>Test route destination</h1>} />
+      </>,
+    );
+
+    const element = getByTestId(props.dataTestId);
+
+    // Assert
+    expect(element).toHaveClass(props.classes.root);
+    expect(element.firstChild).toHaveClass(props.classes.items);
+  });
+
+  it('should be render as expected passing three items', () => {
+    // Arrange
+    const props = {
+      items: [
+        {
+          title: 'test name 1',
+          icon: PeopleAltIcon,
+          linkTo: 'linkTo 1',
+        },
+        {
+          title: 'test name 2',
+          icon: PeopleAltIcon,
+          linkTo: 'linkTo 2',
+        },
+        {
+          title: 'test name 3',
+          icon: PeopleAltIcon,
+          linkTo: 'linkTo 3',
+        },
+      ] as DashboardItemProps[],
+      classes: {
+        dashboard: 'test-dashboard-class',
+        items: 'test-items-class',
+        item: {
+          item: 'test-item-class',
+          icon: 'test-icon-class',
+          name: 'test-name-class',
+        },
+      },
+      dataTestId: 'dashboard-id',
+    };
+
+    // Act
+    const { getAllByRole } = renderWithRouter(
+      <DashboardComponent {...props} />,
+      <>
+        <Route path={props.items[0].linkTo} component={() => <h1>Test route 1</h1>} />
+        <Route path={props.items[1].linkTo} component={() => <h1>Test route 2</h1>} />
+        <Route path={props.items[2].linkTo} component={() => <h1>Test route 3</h1>} />
+      </>,
+    );
+
+    const element = getAllByRole('link');
+
+    // Assert
+    expect(element).toHaveLength(3);
+  });
+});

--- a/admin/src/common/components/test/index.ts
+++ b/admin/src/common/components/test/index.ts
@@ -1,0 +1,1 @@
+export * from './render-with-router';

--- a/admin/src/common/components/test/render-with-router.tsx
+++ b/admin/src/common/components/test/render-with-router.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { HashRouter, Switch } from 'react-router-dom';
+
+export const renderWithRouter = (
+  component: React.ReactElement,
+  routes: React.ReactElement,
+): RenderResult => {
+  return {
+    ...render(
+      <HashRouter>
+        <Switch>{routes}</Switch>
+        {component}
+      </HashRouter>,
+    ),
+  };
+};


### PR DESCRIPTION
@Nasdan
I have been able to override the way to select the specs (Replace getTextByID for getByRole).
But I couldn't do it with the second test of dashboard.component.spec.tsx. 

Do you know how i could do it?

