### PR TITLE
sourceMap Debugging Next JS in browser

### DIFF
--- a/menu-public-portal/next.config.js
+++ b/menu-public-portal/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
-}
+  //only uncomment if sourcemap in production are needed
+  // productionBrowserSourceMaps: true,
+};


### PR DESCRIPTION
# SourceMap for nextjs

By default NextJS 12 has active source Map for debugging.

## Client code
Below an example how I can access to code without changes from source tab in Chrome. 
![image](https://user-images.githubusercontent.com/68061699/153464282-01a44480-b4ff-4abb-99a6-f362451bb1e0.png)
If for any reason you need to access to transformed code, you can change it in chrome dev tools -> options  -> preferences -> soruces -> enable javascript source maps(disabled).
This way you can access to transformed code:
![image](https://user-images.githubusercontent.com/68061699/153464735-20e45833-02d9-4baa-adee-4b4849395086.png)

## node code
Chromiunm based browsers come with node inspector possibilities.
To inspect node code from Chrome browser (code inside getServerSideProps, getStaticPath...) need to follow next steps:

1. Change dev command and execute npm run dev

```
"dev": "NODE_OPTIONS='--inspect' next dev"
```
2. Go to inspect tab:
```
chrome://inspect/
```
3. It should appear a target. If you click inspect it would open a new chrome dev tools when you can debug node code:
![image](https://user-images.githubusercontent.com/68061699/153467361-367625ca-116e-4317-bcd5-a68f0ae05e54.png)

**I think is much easier debug node code from vscode**

## Source map for production
If for any reason you need source maps in production (main reason is you need to analyze your bundle) you can do it in next.config.js with next option:
```
//next.config.js
module.exports = 
  productionBrowserSourceMaps: true,
};
```
## Sources
[Source Maps Next Docs](https://nextjs.org/docs/advanced-features/source-maps)
[Debugging Next Docs](https://nextjs.org/docs/advanced-features/debugging)
[Debuggin Dev.to article](https://dev.to/spe_/debugging-next-js-applications-46b6)