### PR TITLE
add styles to restaurant-list component

### DIFF
--- a/menu-public-portal/src/core/theme/fish.theme.ts
+++ b/menu-public-portal/src/core/theme/fish.theme.ts
@@ -13,10 +13,19 @@ export const fishTheme = createTheme({
       secondary: "#FFFFFF",
     },
   },
+  //TODO: copy same variantes to all themes.
   typography: {
     fontFamily: "Dosis",
-    h3: {
-      borderBottom: "3px solid #35A7CB",
+    h1: {
+      fontSize: `${52 / 16}rem`,
+    },
+    h2: { fontWeight: 600, fontSize: `${22 / 16}rem` },
+    h4: {
+      fontSize: `${18 / 16}rem`,
+      fontWeight: "500",
+    },
+    h5: {
+      fontSize: `${14 / 16}rem`,
     },
   },
 });

--- a/menu-public-portal/src/pods/restaurant-list/restaurant-list.component.tsx
+++ b/menu-public-portal/src/pods/restaurant-list/restaurant-list.component.tsx
@@ -9,44 +9,68 @@ import CardContent from "@mui/material/CardContent";
 import PhoneEnabledIcon from "@mui/icons-material/PhoneEnabled";
 import PlaceIcon from "@mui/icons-material/Place";
 import Button from "@mui/material/Button";
+import { useTheme } from "@mui/material/styles";
+import * as classes from "./restaurant-list.styles";
 interface Props {
   restaurantList: RestaurantInfo[];
 }
 
 const RestaurantList: React.FC<Props> = (props) => {
   const { restaurantList } = props;
-
+  const theme = useTheme();
   const restaurantElements = restaurantList.map((restaurant) => {
     const { name, urlName, address, description, locationUrl, phone } =
       restaurant;
     return (
-      <Card sx={{ maxWidth: 345 }} key={name}>
-        <CardContent>
-          <Typography variant="h6" component="h2">
-            {phone}
-          </Typography>
-          <PhoneEnabledIcon sx={{ color: "secondary.main" }} />
-          <Typography variant="h6" component="h2">
-            {address}
-          </Typography>
-          <Link href={locationUrl}>
-            <a target="_blank">
-              <PlaceIcon sx={{ color: "secondary.main" }} />
-            </a>
-          </Link>
-          <Typography variant="h3" component="h1">
-            {name}
-          </Typography>
-          <Typography variant="h6" component="h2">
-            {description}
-          </Typography>
-        </CardContent>
-        <CardActions>
-          <Button variant="contained" href={routes.restaurant(urlName)}>
-            VER CARTA
-          </Button>
-        </CardActions>
-      </Card>
+      <>
+        <Card
+          sx={{ maxWidth: 345 }}
+          key={name}
+          className={classes.CardContainer(theme)}
+        >
+          <CardContent>
+            <div className={classes.infoRow(theme)}>
+              <Typography variant="h4" component="h2">
+                {phone}
+              </Typography>
+              <PhoneEnabledIcon sx={{ color: "secondary.main" }} />
+            </div>
+            <div className={classes.infoRow(theme)}>
+              <Typography variant="h5" component="h2">
+                {address}
+              </Typography>
+              <Link href={locationUrl}>
+                <a target="_blank">
+                  <PlaceIcon sx={{ color: "secondary.main" }} />
+                </a>
+              </Link>
+            </div>
+            <Link href={routes.restaurant(urlName)}>
+              <a className={classes.anchorDefault}>
+                <Typography
+                  variant="h1"
+                  component="h1"
+                  className={classes.restaurantName(theme)}
+                >
+                  {name}
+                </Typography>
+              </a>
+            </Link>
+            <Typography variant="h2" component="h2">
+              {description}
+            </Typography>
+          </CardContent>
+          <CardActions className={classes.cardActionContainer(theme)}>
+            <Button
+              variant="contained"
+              href={routes.restaurant(urlName)}
+              className={classes.buttonRestaurantList}
+            >
+              VER CARTA
+            </Button>
+          </CardActions>
+        </Card>
+      </>
     );
   });
 
@@ -65,7 +89,12 @@ const RestaurantList: React.FC<Props> = (props) => {
         <Typography variant="h5" component="h5">
           Listado restaurantes
         </Typography>
-        {restaurantElements}
+        <div className={classes.subHeading}>
+          <Typography className={classes.appName}>bar.io</Typography>
+          <Typography>{`© LEMONCODE 2022 { 🍋 }`}</Typography>
+        </div>
+        {/* TODO: apply base global styles */}
+        <ul style={{ margin: 0, padding: 0 }}>{restaurantElements}</ul>
       </main>
 
       <footer>

--- a/menu-public-portal/src/pods/restaurant-list/restaurant-list.styles.ts
+++ b/menu-public-portal/src/pods/restaurant-list/restaurant-list.styles.ts
@@ -1,0 +1,67 @@
+import { css } from "@emotion/css";
+import { Theme } from "@mui/material/styles";
+
+export const restaurantListWrapper = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+`;
+
+export const infoRow = (theme: Theme) => css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${theme.spacing(1)};
+`;
+
+export const numberPhone = (theme: Theme) => css`
+  font-size: ${theme.spacing(2)};
+`;
+
+export const address = (theme: Theme) => css`
+  font-size: ${theme.spacing(1.75)};
+`;
+
+export const buttonRestaurantList = css`
+  font-weight: 600;
+  font-size: ${18 / 16}rem;
+  width: 100%;
+`;
+
+export const CardContainer = (theme: Theme) => css`
+  padding: ${theme.spacing(3)};
+  text-align: center;
+  margin-bottom: ${theme.spacing(15)};
+`;
+
+export const restaurantName = (theme: Theme) => css`
+  margin-bottom: ${theme.spacing(3)};
+  margin-top: ${theme.spacing(5)};
+  border-bottom: 3px solid #35a7cb;
+  padding-bottom: 4px;
+`;
+
+export const cardActionContainer = (theme: Theme) => css`
+  margin-top: ${theme.spacing(10)};
+`;
+
+export const anchorDefault = css`
+  color: inherit;
+  text-decoration: none;
+`;
+
+export const subHeading = css`
+  color: white;
+  background-color: black;
+  /* width is not same as card because not border-box apply globally */
+  max-width: 345px;
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 12px;
+  align-items: baseline;
+`;
+
+export const appName = css`
+  font-weight: 600;
+`;


### PR DESCRIPTION
Add styles to restaurant list component.
Some pending issues:

Apply global styles to remove margin/padding to some elements.
Subheading (black area with bar.io and `© LEMONCODE 2022 { 🍋 } text) has not same width as Card b/c border-box is not applied.
Right now typography variants only used in fishTheme (is the only theme used so far in ThemeProvider)